### PR TITLE
docs: fix spec broken url

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This package is inspired by the [go-ipfs repo migration tool](https://github.com
 
 
 As js-ipfs evolves and new technologies, algorithms and data structures are incorporated it is necessary to
-enable users to transition between versions. Different versions of js-ipfs may expect a different IPFS repo structure or content (see: [IPFS repo spec](https://github.com/ipfs/specs/tree/master/repo), [JS implementation](https://github.com/ipfs/js-ipfs-repo) ).
+enable users to transition between versions. Different versions of js-ipfs may expect a different IPFS repo structure or content (see: [IPFS repo spec](https://github.com/ipfs/specs/blob/master/REPO.md), [JS implementation](https://github.com/ipfs/js-ipfs-repo) ).
 So the IPFS repo is versioned, and this package provides a framework to create migrations to transition
 from one version of IPFS repo to the next/previous version.
 


### PR DESCRIPTION
Specs url was broken. This PR updates it