### PR TITLE
fix: migrate empty repos

### DIFF
--- a/migrations/migration-9/index.js
+++ b/migrations/migration-9/index.js
@@ -11,6 +11,10 @@ const { cidToKey, PIN_DS_KEY, PinTypes } = require('./utils')
 const length = require('it-length')
 
 async function pinsToDatastore (blockstore, datastore, pinstore, onProgress) {
+  if (!await datastore.has(PIN_DS_KEY)) {
+    return
+  }
+
   const mh = await datastore.get(PIN_DS_KEY)
   const cid = new CID(mh)
   const pinRootBuf = await blockstore.get(cidToKey(cid))

--- a/src/index.js
+++ b/src/index.js
@@ -107,11 +107,11 @@ async function migrate (path, repoOptions, toVersion, { ignoreLock = false, onPr
         }
       } catch (e) {
         const lastSuccessfullyMigratedVersion = migration.version - 1
+
         log(`An exception was raised during execution of migration. Setting the repo's version to last successfully migrated version: ${lastSuccessfullyMigratedVersion}`)
         await repoVersion.setVersion(path, lastSuccessfullyMigratedVersion, repoOptions)
 
-        e.message = `During migration to version ${migration.version} exception was raised: ${e.message}`
-        throw e
+        throw new Error(`During migration to version ${migration.version} exception was raised: ${e.stack || e.message || e}`)
       }
 
       log(`Migrating to version ${migration.version} finished`)

--- a/test/migrations/migration-8-test.js
+++ b/test/migrations/migration-8-test.js
@@ -1,4 +1,5 @@
 /* eslint-env mocha */
+/* eslint-disable max-nested-callbacks */
 'use strict'
 
 const { expect } = require('aegir/utils/chai')
@@ -87,6 +88,20 @@ module.exports = (setup, cleanup, repoOptions) => {
 
     afterEach(async () => {
       await cleanup(dir)
+    })
+
+    describe('empty repo', () => {
+      describe('forwards', () => {
+        it('should migrate pins forward', async () => {
+          await migration.migrate(dir, repoOptions, () => {})
+        })
+      })
+
+      describe('backwards', () => {
+        it('should migrate pins backward', async () => {
+          await migration.revert(dir, repoOptions, () => {})
+        })
+      })
     })
 
     it('should migrate blocks forward', async () => {

--- a/test/migrations/migration-9-test.js
+++ b/test/migrations/migration-9-test.js
@@ -121,6 +121,20 @@ module.exports = (setup, cleanup, repoOptions) => {
       await cleanup(dir)
     })
 
+    describe('empty repo', () => {
+      describe('forwards', () => {
+        it('should migrate pins forward', async () => {
+          await migration.migrate(dir, repoOptions, () => {})
+        })
+      })
+
+      describe('backwards', () => {
+        it('should migrate pins backward', async () => {
+          await migration.revert(dir, repoOptions, () => {})
+        })
+      })
+    })
+
     Object.keys(pinsets).forEach(title => {
       const pinset = pinsets[title]
       const pinned = {}


### PR DESCRIPTION
When new repos are created without content, we should still be able to migrate them.

Also, do not overwrite properties on thrown errors as sometimes they are read-only.