### PR TITLE
fix: add cborg to browser field

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "browser": {
     "./src/repo/lock.js": "./src/repo/lock-memory.js",
     "datastore-fs": "datastore-level",
-    "@ipld/car": "@ipld/car/esm/car-browser.js"
+    "@ipld/car": "@ipld/car/esm/car-browser.js",
+    "cborg": "cborg/esm/cborg.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
So modules that use this module can build browser bundles.

Can be removed once `cborg` adds a `main` field to it's `package.json`.