### PR TITLE
chore: remove ts-ignores for cborg

### DIFF
--- a/migrations/migration-9/index.js
+++ b/migrations/migration-9/index.js
@@ -2,7 +2,6 @@
 
 const CID = require('cids')
 const dagpb = require('ipld-dag-pb')
-// @ts-ignore https://github.com/rvagg/cborg/pull/5
 const cbor = require('cborg')
 const multicodec = require('multicodec')
 const multibase = require('multibase')

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "docs": "aegir docs"
   },
   "dependencies": {
-    "cborg": "^1.0.4",
+    "cborg": "^1.0.6",
     "cids": "^1.0.0",
     "datastore-core": "^3.0.0",
     "debug": "^4.1.0",


### PR DESCRIPTION
cborg has been updated with a `"types"` field so we don't need the ignores any more.