### PR TITLE
chore: remove esm hacks

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -12,18 +12,6 @@ const esbuild = {
         build.onResolve({ filter: /^stream$/ }, () => {
           return { path: require.resolve('readable-stream') }
         })
-        build.onResolve({ filter: /^multiformats\/hashes\/digest$/ }, () => {
-          // remove when https://github.com/evanw/esbuild/issues/187 is fixed
-          return { path: require.resolve('multiformats/hashes/digest') }
-        })
-        build.onResolve({ filter: /^multiformats$/ }, () => {
-          // remove when https://github.com/evanw/esbuild/issues/187 is fixed
-          return { path: require.resolve('multiformats') }
-        })
-        build.onResolve({ filter: /^cborg$/ }, () => {
-          // remove when https://github.com/evanw/esbuild/issues/187 is fixed
-          return { path: require.resolve('cborg') }
-        })
       }
     }
   ]

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "debug": "^4.1.0",
     "fnv1a": "^1.0.1",
     "interface-datastore": "^3.0.3",
-    "ipld-dag-pb": "^0.22.1",
+    "ipld-dag-pb": "^0.21.0",
     "it-length": "^1.0.1",
     "multibase": "^4.0.1",
     "multicodec": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,7 @@
   "main": "src/index.js",
   "browser": {
     "./src/repo/lock.js": "./src/repo/lock-memory.js",
-    "datastore-fs": "datastore-level",
-    "@ipld/car": "@ipld/car/esm/car-browser.js",
-    "cborg": "cborg/esm/cborg.js"
+    "datastore-fs": "datastore-level"
   },
   "repository": {
     "type": "git",
@@ -54,7 +52,7 @@
     "debug": "^4.1.0",
     "fnv1a": "^1.0.1",
     "interface-datastore": "^3.0.3",
-    "ipld-dag-pb": "^0.21.0",
+    "ipld-dag-pb": "^0.22.1",
     "it-length": "^1.0.1",
     "multibase": "^4.0.1",
     "multicodec": "^3.0.1",
@@ -68,7 +66,7 @@
     "@ipld/car": "^0.1.2",
     "@types/debug": "^4.1.5",
     "@types/varint": "^6.0.0",
-    "aegir": "^31.0.0",
+    "aegir": "^32.0.2",
     "assert": "^2.0.0",
     "datastore-fs": "^3.0.0",
     "datastore-level": "^4.0.0",


### PR DESCRIPTION
Removes the various hacks put in place to get esm and cjs deps working with exports and no main.